### PR TITLE
[DOC] Add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ A Jupyter kernel that multiplexes all the kernels you have installed.
 python3 -m pip install allthekernels
 ```
 Or to do a dev install from source:
-
 ```
 python3 -m pip install [-e] .
 ```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 A Jupyter kernel that multiplexes all the kernels you have installed.
 
+# Installation
+
+1. Download and extract the contents of this repository or clone it with <code>git clone https://github.com/minrk/allthekernels.git</code>
+2. Install with:
+
+```
+python3 -m pip install allthekernels
+```
+Or to do a dev install from source:
+
+```
+python3 -m pip install [-e] .
+```
+
 # Usage
 
 Specify which kernel a cell should use with `>kernelname`.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Jupyter kernel that multiplexes all the kernels you have installed.
 
+# Usage
+
 Specify which kernel a cell should use with `>kernelname`.
 If no kernel is specified, IPython will be used.
 


### PR DESCRIPTION
Closes #13. Adds installation instructions to the README (plus a usage header to separate sections).

Thanks @minrk for pointing out I have to do this from a fork, did not know this was the standard 👍 .