### PR TITLE
Return value for super.

### DIFF
--- a/allthekernels.py
+++ b/allthekernels.py
@@ -191,7 +191,7 @@ class AllTheKernels(Kernel):
     def do_shutdown(self, restart):
         for kernel in self.kernels.values():
             kernel.manager.shutdown_kernel(False, restart)
-        super().do_shutdown(restart)
+        return super().do_shutdown(restart)
 
 
 class AllTheKernelsApp(IPKernelApp):


### PR DESCRIPTION
In particular the return value is used to check that the kernel has
properly been restarted; without this restarting a atk kernel seem to
regularly fail with a "the kernel appear to have died".